### PR TITLE
[FIX] web: prevent duplicated names in warnings

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_renderer.js
+++ b/addons/web/static/src/js/views/basic/basic_renderer.js
@@ -112,7 +112,9 @@ var BasicRenderer = AbstractRenderer.extend(WidgetAdapterMixin, {
         _.each(this.allFieldWidgets[recordID], function (widget) {
             var canBeSaved = self._canWidgetBeSaved(widget);
             if (!canBeSaved) {
-                invalidFields.push(widget.name);
+                if (!(invalidFields.includes(widget.name))){
+                    invalidFields.push(widget.name);
+                }
             }
             if (widget.el) { // widget may not be started yet
                 widget.$el.toggleClass('o_field_invalid', !canBeSaved);


### PR DESCRIPTION
This changes prevent the warning shows duplicated field names when exists "invisible" fields duplicated in a view.

By example:
If there are 2 fields "name" in a view with different conditions of invisible attrs.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
